### PR TITLE
Fix regression introduced by commit ada2e28

### DIFF
--- a/devices/rowsfire_a107.py
+++ b/devices/rowsfire_a107.py
@@ -649,6 +649,10 @@ class device:
     def connected(self):
         global xplane_connected
         global xp
+
+        if not mf_dev:
+            return
+
         print(f"[A107] X-Plane connected")
         xplane_get_dataref_ids(self.xp)
         print(f"[A107] subsrcibe datarefs... ", end="")


### PR DESCRIPTION
This commit makes it so mf_dev.force_sync() is called even if mf_dev is not initialized, in the case where no Rowsfire A107 device is connected. This makes the script not run properly.