### PR TITLE
Comment out PFP4 entry in winwing_mcdu.py

### DIFF
--- a/devices/winwing_mcdu.py
+++ b/devices/winwing_mcdu.py
@@ -870,7 +870,7 @@ class UsbManager:
             {'vid': 0x4098, 'pid': 0xbb35, 'name': 'PFP 3N - Captain (not tested)', 'mask': DEVICEMASK.PFP3N | DEVICEMASK.CAP},
             {'vid': 0x4098, 'pid': 0xbb39, 'name': 'PFP 3N - First Officer (not tested)', 'mask': DEVICEMASK.PFP3N | DEVICEMASK.FO},
             {'vid': 0x4098, 'pid': 0xbb3d, 'name': 'PFP 3N - Observer (not tested)', 'mask': DEVICEMASK.PFP3N | DEVICEMASK.OBS},
-            {'vid': 0x4098, 'pid': 0xbc1d, 'name': 'PFP 4 (not tested)', 'mask': DEVICEMASK.PFP4},
+            #{'vid': 0x4098, 'pid': 0xbc1d, 'name': 'PFP 4 (not tested)', 'mask': DEVICEMASK.PFP4},
             #{'vid': 0x4098, 'pid': 0xbd1d, 'name': 'PFP 7 (not tested)', 'mask': DEVICEMASK.PFP7}
         ]
         for d in devlist:


### PR DESCRIPTION
I don't have the PFP4 device so I cannot check but it looks like there is a PID error either for the PFP4 or the FCU + EFIS-L combo. They both share the _0xbc1d_ PID in _winwing_mcdu.py_ and _winwing_fcu.py_. This makes it so an FCU + EFIS-L combo is recognized as an MCDU and then the script triggers an exception when winwing_fcu.py tries to connect to the device. This issue is not visible when both an MCDU and the FCU + EFIS-L combo are connected since the MCDU is recognized before going over the PFP4 entry.